### PR TITLE
Fix cange

### DIFF
--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -154,4 +154,28 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20210426-fix-cange-uuid" author="bistenes">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                select count(*) from location where uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc';
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            Part of UHM-4354, moving locations out of PIH Core and into config repos.
+            Fixes Cange's invalid UUID.
+        </comment>
+        <sql>
+            -- If a fixed Cange has been added but the old one still exists, delete the new one.
+            delete l1 from location l1
+            join location l2
+            where l1.id > l2.id and l1.name = l2.name and l1.uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1';
+            
+            -- Update the existing Cange with the bad UUID.
+            update location
+            set uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1'
+            where uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc';
+        </sql>
+
+    </changeSet>
+
 </databaseChangeLog>

--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -165,12 +165,6 @@
             Fixes Cange's invalid UUID.
         </comment>
         <sql>
-            -- If a fixed Cange has been added but the old one still exists, delete the new one.
-            delete l1 from location l1
-            join location l2
-            where l1.location_id > l2.location_id and l1.name = l2.name and l1.uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1';
-            
-            -- Update the existing Cange with the bad UUID.
             update location
             set uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1'
             where uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc';

--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -168,7 +168,7 @@
             -- If a fixed Cange has been added but the old one still exists, delete the new one.
             delete l1 from location l1
             join location l2
-            where l1.id > l2.id and l1.name = l2.name and l1.uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1';
+            where l1.location_id > l2.location_id and l1.name = l2.name and l1.uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1';
             
             -- Update the existing Cange with the bad UUID.
             update location


### PR DESCRIPTION
Preparing for UHM-4354, https://pihemr.atlassian.net/browse/UHM-4354

When run on a new server, Iniz will add Cange with the new UUID and this changeset will not run.

When run on an already-existing server, Iniz will first add all the locations but fail to add the fixed Cange location, complaining that a location named Cange already exists. Then this liquibase script will run and update the existing Cange location.