### PR TITLE
Add line to fix-cange liquibase change, to guard against duplicate Canges

### DIFF
--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -155,6 +155,7 @@
     </changeSet>
 
     <changeSet id="20210426-fix-cange-uuid" author="bistenes">
+        <validCheckSum>3:765ecd3f27c31924a2d28b3586098de9</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">
                 select count(*) from location where uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc';

--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -165,6 +165,12 @@
             Fixes Cange's invalid UUID.
         </comment>
         <sql>
+            -- If a fixed Cange has been added but the old one still exists, delete the new one.
+            delete l1 from location l1
+            join location l2
+            where l1.location_id > l2.location_id and l1.name = l2.name and l1.uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1';
+            
+            -- Update the existing Cange with the bad UUID.
             update location
             set uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc1'
             where uuid = '328f68e4-0370-102d-b0e3-001ec94a0cc';


### PR DESCRIPTION
See https://github.com/PIH/openmrs-config-pihemr/pull/170

This just reverts that last commit, "Remove code that shouldn't ever run." I had been optimistic.