### PR TITLE
UHM-5517: Unable to Save Some Forms when Visit Location does not match Session Location

### DIFF
--- a/configuration/pih/htmlforms/admissionNote.xml
+++ b/configuration/pih/htmlforms/admissionNote.xml
@@ -239,27 +239,42 @@
         </div>
 
     </includeIf>
-    <!-- all users that don't have retroConsultNote privilege can only edit location when active visit -->
-    <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+    <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+    <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
         <div style="display:none">
-            <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
+            <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                      required="true"/>
+            <encounterDate id="encounterDate" default="now"/>
         </div>
         <div id="who-when-where">
-            <p id="who">
-                <label><uimessage code="mirebalais.admissionNote.admittingClinician.label"/></label>
-                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
-            </p>
-            <p id="where">
-                <label><uimessage code="mirebalais.admissionNote.admittedTo.label"/></label>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"  tags="Admission Location"/>
-            </p>
-            <p id="when">
-                <label><uimessage code="mirebalais.admissionNote.admissionDate.label"/></label>
-                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
-            </p>
-        </div>
-        <div style="display:none">
-            <encounterDate id="encounterDate" default="now" />
+            <table id="who-where-when-view">
+                <tr>
+                    <td>
+                        <label>
+                            <uimessage code="emr.patientDashBoard.provider"/>
+                        </label>
+                        <span>
+                            <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                        </span>
+                    </td>
+                    <td>
+                        <label>
+                            <uimessage code="emr.locationRequired"/>
+                        </label>
+                        <span>
+                            <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"  tags="Admission Location"/>
+                        </span>
+                    </td>
+                    <td>
+                        <label>
+                            <uimessage code="emr.patientDashBoard.date"/>
+                        </label>
+                        <span>
+                            <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                        </span>
+                    </td>
+                </tr>
+            </table>
         </div>
     </includeIf>
 

--- a/configuration/pih/htmlforms/ancFollowup.xml
+++ b/configuration/pih/htmlforms/ancFollowup.xml
@@ -144,27 +144,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/ancIntake.xml
+++ b/configuration/pih/htmlforms/ancIntake.xml
@@ -141,27 +141,40 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/cancelAdmission.xml
+++ b/configuration/pih/htmlforms/cancelAdmission.xml
@@ -92,15 +92,17 @@
                 <encounterProviderAndRole default="currentUser" encounterRole="cbfe0b9d-9923-404c-941b-f048adc8cdc0" required="true"/>
             </fieldset>
 
-            <fieldset>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-            </fieldset>
         </div>
     </ifMode>
 
     <span style="display:none">
         <obs conceptId="org.openmrs.module.emrapi:Admission Decision" valueCoded="org.openmrs.module.emrapi:Deny Admission" defaultValue="org.openmrs.module.emrapi:Deny Admission"></obs>
     </span>
+
+    <p>
+        <label><uimessage code="emr.locationRequired"/>:</label>
+        <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
+    </p>
 
     <p>
         <label><uimessage code="mirebalais.cancelAdmissionNote.reason"/>:</label>

--- a/configuration/pih/htmlforms/chemotherapyTreatment.xml
+++ b/configuration/pih/htmlforms/chemotherapyTreatment.xml
@@ -179,12 +179,11 @@
             </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -200,10 +199,10 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/covid19Discharge.xml
+++ b/configuration/pih/htmlforms/covid19Discharge.xml
@@ -192,12 +192,11 @@
 
         </includeIf>
 
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -213,10 +212,11 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="COVID-19 Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/covid19Followup.xml
+++ b/configuration/pih/htmlforms/covid19Followup.xml
@@ -195,12 +195,11 @@
 
         </includeIf>
 
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -216,10 +215,11 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="COVID-19 Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/covid19Intake.xml
+++ b/configuration/pih/htmlforms/covid19Intake.xml
@@ -263,7 +263,7 @@
         </includeIf>
 
         <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and $visit.open)">
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>

--- a/configuration/pih/htmlforms/covid19Intake.xml
+++ b/configuration/pih/htmlforms/covid19Intake.xml
@@ -262,12 +262,11 @@
 
         </includeIf>
 
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -283,10 +282,10 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/delivery.xml
+++ b/configuration/pih/htmlforms/delivery.xml
@@ -142,27 +142,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/dispensing.xml
+++ b/configuration/pih/htmlforms/dispensing.xml
@@ -129,7 +129,7 @@
                     </td>
                     <td>
                         <label><uimessage code="emr.location"/></label>
-                        <span><lookup complexExpression="$ui.format($sessionContext.sessionLocation)"/></span>
+                        <span> <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Dispensing Location"/></span>
                     </td>
                 </ifMode>
 

--- a/configuration/pih/htmlforms/echocardiogram.xml
+++ b/configuration/pih/htmlforms/echocardiogram.xml
@@ -244,12 +244,11 @@
             </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -265,10 +264,10 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/edNote.xml
+++ b/configuration/pih/htmlforms/edNote.xml
@@ -166,27 +166,39 @@
                 </p>
             </div>
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
-                <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                <encounterDate id="encounterDate" default="now" />
+                <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                          required="true"/>
+                <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
                 <table id="who-where-when-view">
                     <tr>
                         <td>
-                            <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                            <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                            <label>
+                                <uimessage code="emr.patientDashBoard.provider"/>
+                            </label>
+                            <span>
+                                <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                            </span>
                         </td>
                         <td>
-                            <label><uimessage code="emr.location"/></label>
-                            <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                            <label>
+                                <uimessage code="emr.locationRequired"/>
+                            </label>
+                            <span>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="ED Note Location"/
+                            </span>
                         </td>
                         <td>
-                            <label><uimessage code="emr.patientDashBoard.date"/></label>
-                            <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                            <label>
+                                <uimessage code="emr.patientDashBoard.date"/>
+                            </label>
+                            <span>
+                                <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                            </span>
                         </td>
                     </tr>
                 </table>

--- a/configuration/pih/htmlforms/labResults.xml
+++ b/configuration/pih/htmlforms/labResults.xml
@@ -144,8 +144,13 @@
             <field>
                 <span class="ui-helper-hidden-accessible"><input type="text"/></span>
             </field>
-
             <p>
+                <label for="location">
+                    <uimessage code="emr.locationRequired"/>
+                </label>
+                <field class="required">
+                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Lab Results Location"/>
+                </field>
                 <label for="specimen-collection-date">
                     <uimessage code="pihcore.lab.specimen_collection_date"/>
                 </label>
@@ -1144,12 +1149,7 @@
                                       required="true"/>
         </fieldset>
 
-        <fieldset>
-            <legend>Where?</legend>
-            <label>Where?</label>
 
-            <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-        </fieldset>
     </div>
 
 

--- a/configuration/pih/htmlforms/mentalHealth.xml
+++ b/configuration/pih/htmlforms/mentalHealth.xml
@@ -310,13 +310,11 @@
             </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
-                <!-- ToDo:  Create and change encounter_role -->
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -332,10 +330,11 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="Consult Note Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/ncd-adult-followup.xml
+++ b/configuration/pih/htmlforms/ncd-adult-followup.xml
@@ -144,27 +144,40 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                       tags="Consult Note Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/ncd-adult-initial.xml
+++ b/configuration/pih/htmlforms/ncd-adult-initial.xml
@@ -144,27 +144,40 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                       tags="Consult Note Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/oncologyConsult.xml
+++ b/configuration/pih/htmlforms/oncologyConsult.xml
@@ -261,12 +261,11 @@
             </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -282,10 +281,11 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="Consult Note Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/oncologyIntake.xml
+++ b/configuration/pih/htmlforms/oncologyIntake.xml
@@ -242,12 +242,11 @@
             </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
                 <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
                                           required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
                 <encounterDate id="encounterDate" default="now"/>
             </div>
             <div id="who-when-where">
@@ -263,10 +262,11 @@
                         </td>
                         <td>
                             <label>
-                                <uimessage code="emr.location"/>
+                                <uimessage code="emr.locationRequired"/>
                             </label>
                             <span>
-                                <lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="Consult Note Location"/>
                             </span>
                         </td>
                         <td>

--- a/configuration/pih/htmlforms/outpatientConsult.xml
+++ b/configuration/pih/htmlforms/outpatientConsult.xml
@@ -141,30 +141,43 @@
                 </div>
 
         </includeIf>
-        <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+        <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+        <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
             <div style="display:none">
-                <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                <encounterDate id="encounterDate" default="now" />
-           </div>
+                <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                          required="true"/>
+                <encounterDate id="encounterDate" default="now"/>
+            </div>
             <div id="who-when-where">
-               <table id="who-where-when-view">
-                  <tr>
-                      <td>
-                        <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                        <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
-                      </td>
-                      <td>
-                        <label><uimessage code="emr.location"/></label>
-                        <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
-                      </td>
-                      <td>
-                        <label><uimessage code="emr.patientDashBoard.date"/></label>
-                          <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
-                      </td>
-                  </tr>
-               </table>
+                <table id="who-where-when-view">
+                    <tr>
+                        <td>
+                            <label>
+                                <uimessage code="emr.patientDashBoard.provider"/>
+                            </label>
+                            <span>
+                                <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                            </span>
+                        </td>
+                        <td>
+                            <label>
+                                <uimessage code="emr.locationRequired"/>
+                            </label>
+                            <span>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="Consult Note Location"/>
+                            </span>
+                        </td>
+                        <td>
+                            <label>
+                                <uimessage code="emr.patientDashBoard.date"/>
+                            </label>
+                            <span>
+                                <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                            </span>
+                        </td>
+                    </tr>
+                </table>
             </div>
         </includeIf>
     </ifMode>

--- a/configuration/pih/htmlforms/patientRegistration-contact.xml
+++ b/configuration/pih/htmlforms/patientRegistration-contact.xml
@@ -20,11 +20,6 @@
         <h2><uimessage code="zl.registration.patient.contactPerson.header"/></h2>
     </ifMode>
 
-    <div class="hidden">
-        <encounterProviderAndRole default="currentUser" encounterRole="cbfe0b9d-9923-404c-941b-f048adc8cdc0" required="true"/>
-        <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-    </div>
-
     <input id="displayEncounterDate" value="false" type="hidden" />
 
     <section id="contactPerson" sectionTag="section" headerStyle="title" headerCode="">

--- a/configuration/pih/htmlforms/patientRegistration-social.xml
+++ b/configuration/pih/htmlforms/patientRegistration-social.xml
@@ -20,11 +20,6 @@
         <h2><uimessage code="zl.registration.patient.social.header"/></h2>
     </ifMode>
 
-    <div class="hidden">
-        <encounterProviderAndRole default="currentUser" encounterRole="cbfe0b9d-9923-404c-941b-f048adc8cdc0" required="true"/>
-        <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-    </div>
-
     <input id="displayEncounterDate" value="false" type="hidden" />
 
     <section id="social" sectionTag="section" headerStyle="title" headerCode="">

--- a/configuration/pih/htmlforms/primary-care-adult-followup.xml
+++ b/configuration/pih/htmlforms/primary-care-adult-followup.xml
@@ -144,27 +144,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Primary Care Consult Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/primary-care-adult-initial.xml
+++ b/configuration/pih/htmlforms/primary-care-adult-initial.xml
@@ -144,27 +144,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Primary Care Consult Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/primary-care-peds-followup.xml
+++ b/configuration/pih/htmlforms/primary-care-peds-followup.xml
@@ -145,27 +145,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Primary Care Consult Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/primary-care-peds-initial.xml
+++ b/configuration/pih/htmlforms/primary-care-peds-initial.xml
@@ -145,27 +145,39 @@
                 </div>
 
             </includeIf>
-            <!-- all users that don't have retroConsultNote privilege cannot edit provider, location or date when active visit -->
-            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNote')) and ($visit.open)">
+            <!-- all users that don't have either retro privilege, or those with retro-this-provider-only but with an active visit, can only edit location -->
+            <includeIf velocityTest="(!$user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote')) or ($user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly') and !$user.hasPrivilege('Task: emr.retroConsultNote') and $visit.open)">
                 <div style="display:none">
-                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05" required="true"/>
-                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-                    <encounterDate id="encounterDate" default="now" />
+                    <encounterProviderAndRole default="currentUser" encounterRole="4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
+                                              required="true"/>
+                    <encounterDate id="encounterDate" default="now"/>
                 </div>
                 <div id="who-when-where">
                     <table id="who-where-when-view">
                         <tr>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.provider"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.provider"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($encounter.provider) #else $ui.format($user.person) #end"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.location"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($encounter.location) #else $ui.format($sessionContext.sessionLocation) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.locationRequired"/>
+                                </label>
+                                <span>
+                                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Primary Care Consult Location"/>
+                                </span>
                             </td>
                             <td>
-                                <label><uimessage code="emr.patientDashBoard.date"/></label>
-                                <span><lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/></span>
+                                <label>
+                                    <uimessage code="emr.patientDashBoard.date"/>
+                                </label>
+                                <span>
+                                    <lookup complexExpression="#if($encounter) $ui.format($fn.startOfDay($encounter.encounterDatetime)) #else $ui.format($fn.startOfDay($formGeneratedDatetime)) #end"/>
+                                </span>
                             </td>
                         </tr>
                     </table>

--- a/configuration/pih/htmlforms/socio-econ.xml
+++ b/configuration/pih/htmlforms/socio-econ.xml
@@ -36,6 +36,19 @@
     </style>
 
     <ifMode mode="VIEW" include="false">
+        <div id="where">
+            <p id="where">
+                <label>
+                    <uimessage code="emr.locationRequired"/>
+                </label>
+                <span>
+                    <encounterLocation default="SessionAttribute:emrContext.sessionLocationId" tags="Consult Note Location"/>
+                </span>
+            </p>
+        </div>
+    </ifMode>
+
+    <ifMode mode="VIEW" include="false">
         <h2>
             <label>
                 <uimessage code="pihcore.socioEconomic.title"/>
@@ -381,12 +394,6 @@
                                       required="true"/>
         </fieldset>
 
-        <fieldset>
-            <legend>Where?</legend>
-            <label>Where?</label>
-
-            <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-        </fieldset>
     </div>
 
     <br/>

--- a/configuration/pih/htmlforms/vitals.xml
+++ b/configuration/pih/htmlforms/vitals.xml
@@ -398,16 +398,6 @@
 
     <span id="most-recent-encounter-title" style="display:none"><!--The Most Recent Encounter app in Core Apps replaces this with the "most recent" label--></span>
 
-    <!-- don't allow editing provider, location, or date if an active visit -->
-    <includeIf velocityTest="$visit.open">
-        <div style="display:none">
-            <encounterProviderAndRole default="currentUser" encounterRole="98bf2792-3f0a-4388-81bb-c78b29c0df92"
-                                      required="true"/>
-            <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"/>
-            <encounterDate id="encounterDate" default="now"/>
-        </div>
-    </includeIf>
-
     <section id="vitals" sectionTag="section" headerStyle="title" headerCode="mirebalais.vitals.title">
 
         <ifMode mode="VIEW" include="false">

--- a/configuration/pih/htmlforms/vitals.xml
+++ b/configuration/pih/htmlforms/vitals.xml
@@ -461,6 +461,35 @@
 
                 </fieldset>
             </includeIf>
+
+            <!-- only allow location if an active visit or user has no retro privileges -->
+            <includeIf velocityTest="$visit.open or ($user.hasPrivilege('Task: emr.retroConsultNote') and $user.hasPrivilege('Task: emr.retroConsultNoteThisProviderOnly'))">
+                <fieldset field-separator=", ">
+
+                    <legend><uimessage code="pihcore.details"/></legend>
+                    <h3><uimessage code="pihcore.details"/></h3>
+
+                    <div style="display:none">
+                        <encounterProviderAndRole default="currentUser" encounterRole="98bf2792-3f0a-4388-81bb-c78b29c0df92"
+                                                      required="true"/>
+                    </div>
+
+                    <label>
+                        <uimessage code="emr.locationRequired"/>
+                    </label>
+                    <span>
+                        <p class="required">
+                            <field>
+                                <encounterLocation default="SessionAttribute:emrContext.sessionLocationId"
+                                                   tags="Vitals Location"/>
+                            </field>
+                        </p>
+                    </span>
+                    <div  style="display:none">
+                        <encounterDate id="encounterDate" default="now"/>
+                    </div>
+                </fieldset>
+            </includeIf>
         </ifMode>
 
         <fieldset field-separator=" ">


### PR DESCRIPTION
So, now that we've got situations where there are multiple visit locations on a single server, we have an issue if the user's session location does not match the visit location.

As a workaround for this, we will *always* allow users to change the encounter location.

This is basically a sample of the change made to COVID Admission form for review, which I'll then have to cut-and-paste to all other forms.

It also includes a change to the Vitals form, which as a different layout.