### PR TITLE
Fix the release job

### DIFF
--- a/ci/release-finish.sh
+++ b/ci/release-finish.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# This versions and releases a config repo.
+# This versions a config repo to the next SNAPSHOT version,
+# and updates pihcore to refer to the correct SNAPSHOT version.
 #
 # It requires the repo name as an argument.
 # It accepts the environment variables
@@ -71,8 +72,10 @@ echo DEVELOPMENT_VERSION ${DEVELOPMENT_VERSION}
 ### Prep for next development cycle
 sed -i "0,/<\/version>/{s/version>.*<\/version/version>${DEVELOPMENT_VERSION}<\/version/}" pom.xml
 git add pom.xml
-git commit -m "update to ${DEVELOPMENT_VERSION}"
-git push central master
+if git diff --cached --exit-code; then
+  git commit -m "update to ${DEVELOPMENT_VERSION}"
+  git push central master
+fi
 
 ### Update development version in pihcore
 
@@ -98,6 +101,8 @@ sed -n -i \
 #           #   the `-n` flag. I struggle to explain why.
 
 git add api/pom.xml
-git commit -m "Update $1 version to ${DEVELOPMENT_VERSION}"
-git push central `git rev-parse --abbrev-ref HEAD`
+if git diff --cached --exit-code; then
+  git commit -m "Update $1 version to ${DEVELOPMENT_VERSION}"
+  git push central `git rev-parse --abbrev-ref HEAD`
+fi
 cd ..

--- a/ci/release-finish.sh
+++ b/ci/release-finish.sh
@@ -72,7 +72,7 @@ echo DEVELOPMENT_VERSION ${DEVELOPMENT_VERSION}
 ### Prep for next development cycle
 sed -i "0,/<\/version>/{s/version>.*<\/version/version>${DEVELOPMENT_VERSION}<\/version/}" pom.xml
 git add pom.xml
-if git diff --cached --exit-code; then
+if ! git diff --cached --exit-code; then
   git commit -m "update to ${DEVELOPMENT_VERSION}"
   git push central master
 fi
@@ -101,7 +101,7 @@ sed -n -i \
 #           #   the `-n` flag. I struggle to explain why.
 
 git add api/pom.xml
-if git diff --cached --exit-code; then
+if ! git diff --cached --exit-code; then
   git commit -m "Update $1 version to ${DEVELOPMENT_VERSION}"
   git push central `git rev-parse --abbrev-ref HEAD`
 fi

--- a/ci/release-prepare.sh
+++ b/ci/release-prepare.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# This versions and releases a config repo.
+#
+# It requires the repo name as an argument.
+# It accepts the environment variables
+#   `RELEASE_VERSION`
+#
+# This script requires that the config repo dependency entries
+# in openmrs-module-pihcore/api/pom.xml have the version line
+# immediately following the `artifactId` line. e.g.
+#
+# <groupId>org.pih.openmrs</groupId>
+# <artifactId>openmrs-config-ces</artifactId>
+# <version>1.0.0-SNAPSHOT</version>
+#
+# If the version line is not immediately after the artifactId line,
+# terrible things will happen.
+#
+
+set -e  # die on error
+set -o pipefail  # die on error within pipes
+
+### Validate argument
+
+if [ "$1" = "" ]
+then
+  echo "Usage: $0 <name of repository to be released>"
+  exit
+fi
+
+### Configure Github
+
+git config --global user.email "pihinformatics@gmail.com"
+git config --global user.name "pihinformatics"
+
+git remote remove central || true
+git remote add central git@github.com:PIH/$1.git
+git fetch central
+
+### Clean up
+
+# For these to work, it's important that the Bamboo has git repository caching disabled for this repo/job.
+# Reset
+git reset --hard central/master
+# Clean up stray local tags that didn't get pushed
+git tag -l | xargs git tag -d
+git fetch central --tags
+
+### Figure out versions
+
+CURRENT_RELEASE_TARGET=$(grep -m 1 "<version>" pom.xml | sed 's/.*version>\(.*\)-SNAPSHOT<\/version.*/\1/')
+
+if [ -z "${RELEASE_VERSION}" ]; then
+    RELEASE_VERSION=$CURRENT_RELEASE_TARGET
+fi
+
+echo RELEASE_VERSION ${RELEASE_VERSION}
+
+### Do release
+
+set -x  # print all commands
+
+# Update version to release version
+sed -i "0,/<\/version>/{s/version>.*-SNAPSHOT<\/version/version>${RELEASE_VERSION}<\/version/}" pom.xml
+git add pom.xml
+git commit -m "${RELEASE_VERSION} release"
+git tag ${RELEASE_VERSION}
+git push central master --tags

--- a/ci/release-prepare.sh
+++ b/ci/release-prepare.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# This versions and releases a config repo.
+# This versions a config repo to its release version,
+# preparing it for a Maven deploy.
 #
 # It requires the repo name as an argument.
 # It accepts the environment variables

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -82,6 +82,9 @@ git commit -m "${RELEASE_VERSION} release"
 git tag ${RELEASE_VERSION}
 git push central master --tags
 
+# Deploy
+mvn clean deploy -U -DdeployRelease -Dgpg.passphrase=${bamboo.gpg.passphrase} -Dgpg.keyname=${bamboo.gpg.keyname}
+
 # Prep for next development cycle
 sed -i "0,/<\/version>/{s/version>.*<\/version/version>${DEVELOPMENT_VERSION}<\/version/}" pom.xml
 git add pom.xml

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -31,13 +31,15 @@ fi
 
 ### Configure Github
 
-git remote remove central || true
-git remote add central git@github.com:PIH/$1.git
 git config --global user.email "pihinformatics@gmail.com"
 git config --global user.name "pihinformatics"
+
+git remote remove central || true
+git remote add central git@github.com:PIH/$1.git
 git fetch central
 
 cd openmrs-module-pihcore
+git remote remove central || true
 git remote add central git@github.com:PIH/openmrs-module-pihcore.git
 git fetch central
 cd ..

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -2,7 +2,11 @@
 #
 # This versions and releases a config repo.
 #
-# It reuqires the repo name as an argument. It accepts the environment variables
+# It requires the repo name as an argument.
+# It requires the environment variables
+#   `GPG_KEYNAME`
+#   `GPG_PASSPHRASE`
+# It accepts the environment variables
 #   `RELEASE_VERSION`
 #   `DEVELOPMENT_VERSION`
 #
@@ -85,7 +89,7 @@ git tag ${RELEASE_VERSION}
 git push central master --tags
 
 # Deploy
-mvn clean deploy -U -DdeployRelease -Dgpg.passphrase=${bamboo.gpg.passphrase} -Dgpg.keyname=${bamboo.gpg.keyname}
+mvn clean deploy -U -DdeployRelease -Dgpg.passphrase=${GPG_PASSPHRASE} -Dgpg.keyname=${GPG_KEYNAME}
 
 # Prep for next development cycle
 sed -i "0,/<\/version>/{s/version>.*<\/version/version>${DEVELOPMENT_VERSION}<\/version/}" pom.xml


### PR DESCRIPTION
Currently, it doesn't actually deploy the maven artifact for the release version. This splits it into two so that Bamboo can run a Maven step.

See https://bamboo.pih-emr.org/build/admin/edit/editBuildTasks.action?buildKey=MIREBALAIS-CC-VR