### PR TITLE
UHM-6871: Get the new O3 ordering into the build

### DIFF
--- a/configuration/frontend/base-config.json
+++ b/configuration/frontend/base-config.json
@@ -31,5 +31,17 @@
       "generalPatientNoteUuid": "3cd9d956-26fe-102b-80cb-0017a47871b2",
       "midUpperArmCircumferenceUuid": "4326b04b-3158-417a-bb8d-ad022295b0f4"
     }
+  },
+  "@openmrs/esm-patient-medications-app": {
+    "durationUnitsConcept": "3cd706b8-26fe-102b-80cb-0017a47871b2",
+    "daysDurationUnit": {
+      "uuid": "3cd706b8-26fe-102b-80cb-0017a47871b2"
+    },
+    "careSettingUuid": "6f0c9a92-6f24-11e3-af88-005056821db0",
+    "quantityUnitsUuid": "162395AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "clinicianEncounterRole": "c458d78e-8374-4767-ad58-9f8fe276e01c",
+    "drugOrderTypeUUID": "131168f4-15f5-102d-96e4-000c29c2a5d7",
+    "drugOrderEncounterType": "0b242b71-5b60-11eb-8f5a-0242ac110002",
+    "_comment": "TODO: drug order encounter type refers to Drug Order Documentation encounter; we likely will need another encounter type, or, better yet, none at all"
   }
 }


### PR DESCRIPTION
This adds the proper configuration for the Medications app (order baskset) based on the PIH EMR metadata.
Note the comment I added about not wanting to us the Drug Order Encounter long-term... hopefully we will have some sort of encounter context feature set up before we need to go live with this.