### PR TITLE
SL-548 Move death global properties from sl; moved emrapi death date …

### DIFF
--- a/configuration/globalproperties/gp.xml
+++ b/configuration/globalproperties/gp.xml
@@ -38,11 +38,21 @@
             <property>concept.weight</property>
             <value>${concept.weightKG.uuid}</value>
         </globalProperty>
+
         <globalProperty>
             <property>concept.causeOfDeath</property>
             <!-- Concept: 	CAUSE OF DEATH FROM DEATH CERTIFICATE, CIEL:1814 -->
             <value>1814AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</value>
         </globalProperty>
+        <globalProperty>
+            <property>coreapps.deceasedDateUsingTime</property>
+            <value>true</value>
+        </globalProperty>
+        <globalProperty>
+            <property>coreapps.deceasedDateUsingTimeMinuteStep</property>
+            <value>1</value>
+        </globalProperty>
+
         <globalProperty>
             <property>order.drugRoutesConceptUuid</property>
             <!-- Concept: Routes of administration, CIEL:162394 -->

--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -869,4 +869,18 @@
             where  priority = (select concept_id from concept where uuid='1882AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA') ; -- Emergency (status)
         </sql>
     </changeSet>
+
+    <changeSet id="20240228-migrate-to-datetime-death" author="ball">
+        <comment>
+            Migrate date of death to datetime concept.  No change of time (00:00:00).
+        </comment>
+        <sql>
+            update obs
+            set concept_id = (select concept_id from concept where uuid='8d36db2c-e39c-4029-92f3-c85959f6f2e1')  -- Datetime of death (datetime)
+            where concept_id = (select concept_id from concept where uuid='3cde64e4-26fe-102b-80cb-0017a47871b2')  -- Date of death (date)
+              and voided = 0;
+        </sql>
+    </changeSet>
+
+
 </databaseChangeLog>


### PR DESCRIPTION
…mapping; migrate date of death obs to datetime

Packaging these together since they are all about switching "date of death" to "datetime of death".

- ocl concepts:  Nothing to review here, but it will move the emrapi mapping to datetime
- gp.xml: Moved these global properties from sl (different PR)
- liquibase.xml: migrates all the "date of death" obs to "datetime of death"