### PR TITLE
Enable new queue page

### DIFF
--- a/configuration/frontend/base-config.json
+++ b/configuration/frontend/base-config.json
@@ -60,7 +60,16 @@
     "extensionSlots": {
       "homepage-dashboard-slot": {
         "remove": [
-          "patient-lists-dashboard-link"
+          "patient-lists-dashboard-link",
+          "service-queues-dashboard-link"
+        ],
+        "add": [
+          "queue-table-by-status-menu-dashboard-link"
+        ],
+        "order": [
+          "home-widget-db-link",
+          "queue-table-by-status-menu-dashboard-link",
+          "clinical-appointments-dashboard-link"
         ]
       }
     }


### PR DESCRIPTION
Once / if we get my PR from patient management merged that adds the new LHN queue view, this PR would update our config to remove the existing extension and add this in it's place