### PR TITLE
UHM-8098: update multiple edd elements on the same form

### DIFF
--- a/configuration/pih/htmlforms/covid19Intake.xml
+++ b/configuration/pih/htmlforms/covid19Intake.xml
@@ -349,7 +349,7 @@
                             <span id="calculated-edd-label">
                                 <uimessage code="pihcore.calculatedEstimatedDeliveryDate"/>:&#160;
                             </span><br/>
-                            <span id='calculated-edd' class="calculated-edd value"></span>
+                            <span id='calculated-edd-value' class="calculated-edd value"></span>
                         </span>
                     </div>
                 </div>

--- a/configuration/pih/htmlforms/section-history.xml
+++ b/configuration/pih/htmlforms/section-history.xml
@@ -518,7 +518,7 @@
                                     <span id="calculated-edd-label">
                                         <uimessage code="pihcore.calculatedEstimatedDeliveryDate"/>:&#160;
                                     </span><br/>
-                                    <span id='calculated-edd' class="calculated-edd value"></span>
+                                    <span id='calculated-edd-value' class="calculated-edd value"></span>
                                 </span>
                             </div>
                         </div>

--- a/configuration/pih/htmlforms/section-obgyn-initial.xml
+++ b/configuration/pih/htmlforms/section-obgyn-initial.xml
@@ -1509,7 +1509,7 @@
                                             <span id="calculated-edd-label">
                                                 <uimessage code="pihcore.calculatedEstimatedDeliveryDate"/>:&#160;
                                             </span><br/>
-                                            <span id='calculated-edd' class="calculated-edd value"></span>
+                                            <span id='calculated-edd-value' class="calculated-edd value"></span>
                                         </span>
                                     </div>
                                 </div>
@@ -1710,7 +1710,7 @@
                         <span id="calculated-edd-label">
                             <uimessage code="pihcore.calculatedEstimatedDeliveryDate"/>:&#160;
                         </span><br/>
-                        <span id='calculated-edd' class="calculated-edd value"></span>
+                        <span id='calculated-edd-value' class="calculated-edd value"></span>
                     </span>
                 </div>
             </div>

--- a/configuration/pih/scripts/global/mch.js
+++ b/configuration/pih/scripts/global/mch.js
@@ -26,16 +26,16 @@ function setUpEdd(currentEncounterDate, msgWeeks) {
       const gestAgeText = calculateGestationalDays(lastPeriodDate, currentEncounterDate, msgWeeks);
       const edd = calculateExpectedDeliveryDate(lastPeriodDate);
       const locale = window.sessionContext.locale || navigator.language;
-      jq("#calculated-edd-and-gestational").show();
+      jq("div[id^=calculated-edd-and-gestational]").show();
       getField("edd.value").datepicker("setDate", edd);
-      jq("#calculated-edd").text((Intl.DateTimeFormat(locale, { dateStyle: "medium" })).format(edd));
-      jq("#calculated-gestational-age-value").text(gestAgeText);
+      jq("span[id^=calculated-edd-value]").text((Intl.DateTimeFormat(locale, { dateStyle: "medium" })).format(edd));
+      jq("span[id^=calculated-gestational-age-value]").text(gestAgeText);
     } else {
-      jq("#calculated-edd-and-gestational").hide();
+      jq("div[id^=calculated-edd-and-gestational]").hide();
     }
   };
 
-  jq("#calculated-edd-and-gestational").hide();
+  jq("div[id^=calculated-edd-and-gestational]").hide();
   jq("#lastPeriodDate input[type='hidden']").change(function () {
     updateEdd();
   });


### PR DESCRIPTION
@mseaton  and @lnball, if you insist on using multiple elements with the same ID, I found another jquery syntax that allows us to select multiple elements whose IDs start with the same string:
**jq("div[id^=calculated-edd-and-gestational]").show();**

<img width="1147" alt="Screenshot 2024-08-01 at 3 45 11 PM" src="https://github.com/user-attachments/assets/36533040-d044-4778-83a3-c563d74dd22f">
