### PR TITLE
SL-965 add hotjar for SL training server

### DIFF
--- a/configuration/pih/scripts/global/hotjar.js
+++ b/configuration/pih/scripts/global/hotjar.js
@@ -1,0 +1,12 @@
+// hotjar is a 3rd party behavioral analytics tool that allows us to record user UI 
+// interactions. We enable it at selected training servers
+if("sle-kgh-inf-omrstest" === window.location.host) {
+  (function(h,o,t,j,a,r){
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+      h._hjSettings={hjid:6424451,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
+  })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+}


### PR DESCRIPTION
This is ready for review, but marking this as draft, as IT is in the process of making a external domain for this server, so the hard-coded address `"sle-kgh-inf-omrstest"` will change.