### PR TITLE
SL-1332: migrate HIV positive and Syphilis positive results

### DIFF
--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -1299,4 +1299,27 @@
         <sqlFile endDelimiter=";" path="sql/set-inborn-visit-attribute.sql" relativeToChangelogFile="true" stripComments="true" />
     </changeSet>
 
+    <changeSet id="20260513-migrate-hiv-rapid-test" author="PIH">
+        <comment>
+            SL-1332, Migrate HIV rapid test obs.
+            For each non-voided obs of concept CIEL:169624 (HIV/syphilis rapid test) whose value_coded is
+            concept CIEL:138571 (HIV), create a new obsgroup (concept
+            PIH:11522, HIV test construct) and a child obs (concept CIEL:163722, HIV rapid test,
+            value_coded CIEL:703, Positive) carrying the same person/encounter/datetime/
+            location/creator, then void the source obs.
+        </comment>
+        <sqlFile endDelimiter=";" path="sql/migrate-hiv-rapid-test.sql" relativeToChangelogFile="true" stripComments="true" />
+    </changeSet>
+    <changeSet id="20260513-migrate-syphilis-rapid-test" author="PIH">
+        <comment>
+            SL-1332, Migrate Syphilis rapid test obs.
+            For each non-voided obs of concept CIEL:169624 (HIV/syphilis rapid test) whose value_coded is
+            concept CIEL:136014 (Syphilis), create a new obsgroup (concept
+            PIH:11523, Syphilis test construct) and a child obs (concept CIEL:165303, Syphilis rapid test,
+            value_coded CIEL:1228, Positive) carrying the same person/encounter/datetime/
+            location/creator, then void the source obs.
+        </comment>
+        <sqlFile endDelimiter=";" path="sql/migrate-syphilis-rapid-tests.sql" relativeToChangelogFile="true" stripComments="true" />
+    </changeSet>
+
 </databaseChangeLog>

--- a/configuration/pih/liquibase/sql/migrate-hiv-rapid-test.sql
+++ b/configuration/pih/liquibase/sql/migrate-hiv-rapid-test.sql
@@ -1,0 +1,53 @@
+SET @old_hiv_test_concept_uuid          = '7ff67b85-7c94-49f6-8187-786fb8f9dbdc';
+SET @old_hiv_test_result_value_uuid     = '9f2bc0b1-3c77-4850-9fbc-9d138813fa4c';
+SET @new_hiv_test_obsgroup_concept_uuid = '56740c9f-d86e-4240-ad59-7552385a8691';
+SET @new_hiv_test_result_concept_uuid   = '3cd6c946-26fe-102b-80cb-0017a47871b2';
+SET @new_hiv_test_result_value_uuid     = '3cd3a7a2-26fe-102b-80cb-0017a47871b2';
+
+DROP TABLE IF EXISTS tmp_migrate_hiv_test;
+
+CREATE TABLE tmp_migrate_hiv_test AS
+SELECT o.*
+FROM obs o
+WHERE o.voided = 0
+  AND o.concept_id  = (SELECT concept_id FROM concept WHERE uuid = @old_hiv_test_concept_uuid)
+  AND o.value_coded = (SELECT concept_id FROM concept WHERE uuid = @old_hiv_test_result_value_uuid);
+
+ALTER TABLE tmp_migrate_hiv_test ADD COLUMN new_obs_group_uuid CHAR(38) DEFAULT NULL;
+ALTER TABLE tmp_migrate_hiv_test ADD COLUMN new_obs_group_id   INT(11)  DEFAULT NULL;
+
+UPDATE tmp_migrate_hiv_test SET new_obs_group_uuid = UUID();
+
+INSERT INTO obs
+    (person_id, concept_id, encounter_id, obs_datetime, location_id, creator,
+     date_created, uuid)
+SELECT t.person_id,
+       (SELECT concept_id FROM concept WHERE uuid = @new_hiv_test_obsgroup_concept_uuid),
+       t.encounter_id, t.obs_datetime, t.location_id, t.creator,
+       NOW(), t.new_obs_group_uuid
+FROM tmp_migrate_hiv_test t;
+
+UPDATE tmp_migrate_hiv_test t, obs grp
+   SET t.new_obs_group_id = grp.obs_id
+ WHERE grp.uuid = t.new_obs_group_uuid;
+
+INSERT INTO obs
+    (person_id, concept_id, value_coded, encounter_id, obs_datetime, location_id, creator,
+     obs_group_id, date_created, uuid)
+SELECT t.person_id,
+       (SELECT concept_id FROM concept WHERE uuid = @new_hiv_test_result_concept_uuid),
+       (SELECT concept_id FROM concept WHERE uuid = @new_hiv_test_result_value_uuid),
+       t.encounter_id, t.obs_datetime, t.location_id, t.creator,
+       t.new_obs_group_id,
+       NOW(), UUID()
+FROM tmp_migrate_hiv_test t
+WHERE t.new_obs_group_id IS NOT NULL;
+
+UPDATE obs o, tmp_migrate_hiv_test t
+   SET o.voided      = 1,
+       o.voided_by   = t.creator,
+       o.date_voided = NOW(),
+       o.void_reason = 'SL-1332, migrate HIV rapid test'
+ WHERE o.obs_id = t.obs_id;
+
+DROP TABLE IF EXISTS tmp_migrate_hiv_test;

--- a/configuration/pih/liquibase/sql/migrate-syphilis-rapid-tests.sql
+++ b/configuration/pih/liquibase/sql/migrate-syphilis-rapid-tests.sql
@@ -1,0 +1,53 @@
+SET @old_syphilis_test_concept_uuid          = '7ff67b85-7c94-49f6-8187-786fb8f9dbdc';
+SET @old_syphilis_test_result_value_uuid     = 'ef2bfd0f-db05-450c-8e1c-280a2c4d7a5e';
+SET @new_syphilis_test_obsgroup_concept_uuid = 'ea5d701a-a8ec-48b2-84c3-2df1c25ac080';
+SET @new_syphilis_test_result_concept_uuid   = '165303AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+SET @new_syphilis_test_result_positive_uuid  = '3cd8f3f6-26fe-102b-80cb-0017a47871b2';
+
+DROP TABLE IF EXISTS tmp_migrate_syphilis_test;
+
+CREATE TABLE tmp_migrate_syphilis_test AS
+SELECT o.*
+FROM obs o
+WHERE o.voided = 0
+  AND o.concept_id  = (SELECT concept_id FROM concept WHERE uuid = @old_syphilis_test_concept_uuid)
+  AND o.value_coded = (SELECT concept_id FROM concept WHERE uuid = @old_syphilis_test_result_value_uuid);
+
+ALTER TABLE tmp_migrate_syphilis_test ADD COLUMN new_obs_group_uuid CHAR(38) DEFAULT NULL;
+ALTER TABLE tmp_migrate_syphilis_test ADD COLUMN new_obs_group_id   INT(11)  DEFAULT NULL;
+
+UPDATE tmp_migrate_syphilis_test SET new_obs_group_uuid = UUID();
+
+INSERT INTO obs
+(person_id, concept_id, encounter_id, obs_datetime, location_id, creator,
+ date_created, uuid)
+SELECT t.person_id,
+       (SELECT concept_id FROM concept WHERE uuid = @new_syphilis_test_obsgroup_concept_uuid),
+       t.encounter_id, t.obs_datetime, t.location_id, t.creator,
+       NOW(), t.new_obs_group_uuid
+FROM tmp_migrate_syphilis_test t;
+
+UPDATE tmp_migrate_syphilis_test t, obs grp
+SET t.new_obs_group_id = grp.obs_id
+WHERE grp.uuid = t.new_obs_group_uuid;
+
+INSERT INTO obs
+(person_id, concept_id, value_coded, encounter_id, obs_datetime, location_id, creator,
+ obs_group_id, date_created, uuid)
+SELECT t.person_id,
+       (SELECT concept_id FROM concept WHERE uuid = @new_syphilis_test_result_concept_uuid),
+       (SELECT concept_id FROM concept WHERE uuid = @new_syphilis_test_result_positive_uuid),
+       t.encounter_id, t.obs_datetime, t.location_id, t.creator,
+       t.new_obs_group_id,
+       NOW(), UUID()
+FROM tmp_migrate_syphilis_test t
+WHERE t.new_obs_group_id IS NOT NULL;
+
+UPDATE obs o, tmp_migrate_syphilis_test t
+SET o.voided      = 1,
+    o.voided_by   = t.creator,
+    o.date_voided = NOW(),
+    o.void_reason = 'SL-1332, migrate Syphilis rapid test'
+WHERE o.obs_id = t.obs_id;
+
+DROP TABLE IF EXISTS tmp_migrate_syphilis_test;


### PR DESCRIPTION
@mogoodrich , this is just migrating the old HIV/syphilis rapid test positive results into two separate obsgroups, one for HIV Rapid test and one for Syphils rapid test. Thanks!