### PR TITLE
UHM-9314 Added changeSet for duplicate RxNORM mappings

### DIFF
--- a/configuration/pih/liquibase/liquibase.xml
+++ b/configuration/pih/liquibase/liquibase.xml
@@ -1289,4 +1289,30 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20260526-delete-2-narrow-rx-norm-mappings" author="ball">
+        <comment>
+            UHM-9314 - Delete NARROWER-THAN RxNORM mappings replaced by SAME-AS mappings
+        </comment>
+        <sql>
+            -- Delete RxNORM NARROWER-THAN mapping on Dorzolamide / timolol
+            delete from concept_reference_map
+             where concept_map_type_id IN (select concept_map_type_id from concept_map_type where name like 'NARROWER-THAN')
+               and concept_id IN (select concept_id from concept where uuid like '104546AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
+               and concept_reference_term_id IN
+                    (select concept_reference_term_id from concept_reference_term
+                      where code like '662263'
+                       and concept_source_id = (select concept_source_id from concept_reference_source where name like 'RxNORM'));
+
+
+            -- Deleted RxNORM NARROWER-THAN mapping on Dimethicone / Magaldrate
+            delete from concept_reference_map
+             where concept_map_type_id IN (select concept_map_type_id from concept_map_type where name like 'NARROWER-THAN')
+               and concept_id IN (select concept_id from concept where uuid like '6e203f4e-03ad-4c9e-b160-234ee092cc02')
+               and concept_reference_term_id IN
+                    (select concept_reference_term_id from concept_reference_term
+                      where code IN ('29151','324072')
+                        and concept_source_id = (select concept_source_id from concept_reference_source where name like 'RxNORM'));
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
I tested it locally @mogoodrich but good if you can test on Cange.  There's no pre-condition.  no harm if the NARROWER-THAN mappings don't exist.