### PR TITLE
UHM-9321 Created starter code for estimated delivery date (and GA)

### DIFF
--- a/configuration/pih/subforms/est-delivery-date-ga-initial.xml
+++ b/configuration/pih/subforms/est-delivery-date-ga-initial.xml
@@ -1,0 +1,60 @@
+<!-- The htmlform code for Initial estimated delivery date and gestational age -->
+<div id="edd-and-ga-widget">
+    <subform path="configuration/pih/subforms/est-delivery-date-ga.js"/>
+    <subform path="configuration/pih/subforms/est-delivery-date-ga.css"/>
+
+    <div class="two-columns">
+        <!-- Last menstrual period (LMP or DDR) -->
+        <div>
+            <label>
+                <uimessage code="pihcore.pregnancy.lastPeriod"/>
+            </label>
+            <span class="small">
+                <obs id="lastPeriodDate" conceptId="CIEL:1427" allowFutureDates="false"/>
+            </span>
+        </div>
+
+        <!-- Due date (DPA) -->
+        <div>
+            <label>
+                <uimessage code="pihcore.pregnancy.dueDate"/>
+            </label>
+            <span class="small">
+                <obs id="edd" conceptId="CIEL:5596" allowFutureDates="true" allowPastDates="true"/>
+            </span>
+        </div>
+    </div>
+
+    <div id="calculated-edd-and-gestational" class="two-columns hidden">
+        <div>
+            <span id="calculated-gestational-age-wrapper">
+                <span id="calculated-gestational-age-label">
+                    <uimessage code="pihcore.calculatedGestationalAge"/>:&#160;
+                </span>
+                <span id='calculated-gestational-age-value' class="calculated-gestational-age-value value"></span>
+            </span>
+        </div>
+        <div>
+            <span id="calculated-edd-wrapper">
+                <span id="calculated-edd-label">
+                    <uimessage code="pihcore.calculatedEstimatedDeliveryDate"/>:&#160;
+                </span>
+                <span id='calculated-edd' class="calculated-edd value"></span>
+            </span>
+        </div>
+    </div>
+    <div>
+        <p>
+            <br/>
+            <span id="gestational-age-wrapper">
+                <label>
+                    <uimessage code="pihcore.gestational.age" /><uimessage code="pihcore.gestational.age.instructions" />
+                </label>
+
+                <span>
+                    <obs conceptId="CIEL:1438" class="value gestationalAge" showUnits="true" unitsCssClass="append-to-value" size="80"/>
+                </span>
+            </span>
+        </p>
+    </div>
+</div>

--- a/configuration/pih/subforms/est-delivery-date-ga.css
+++ b/configuration/pih/subforms/est-delivery-date-ga.css
@@ -1,0 +1,17 @@
+
+/* style guide for estimated delivery date */
+.gestationalAge {
+    white-space: nowrap;
+    display:    inline-flex;
+}
+
+.gestationalAge span{
+    margin-left: 10px;
+    margin-top: 10px;
+}
+
+.gestationalAge input[type="text"]{
+    min-width: 2%;
+    width: 80px;
+    white-space: nowrap;
+}

--- a/configuration/pih/subforms/est-delivery-date-ga.js
+++ b/configuration/pih/subforms/est-delivery-date-ga.js
@@ -1,0 +1,56 @@
+
+// This calculates the shows the estimated delivery date (edd) and gestational age (GA)
+
+jq(function() {
+    var encounterDate = '<lookup expression="encounter.getEncounterDatetime().getTime()" />';
+    setUpEdd(encounterDate,'<uimessage code="pihcore.weeks" />');
+    validateEstimatedDeliveryDate("lastPeriodDate", new Date(+encounterDate), '<uimessage code="pihcore.errors.lastPeriodDateField.invalidDate" />');
+    validateEstimatedDeliveryDate("edd", new Date(+encounterDate), '<uimessage code="pihcore.errors.eddField.invalidDate" />');
+    eddCannotBeOlderThanTwoWeeks("edd", new Date(+encounterDate), '<uimessage code="pihcore.errors.eddField.twoWeeksOlder" />');
+
+    // handlers for next and submit buttons, see nextAndSubmitButtons.js
+    setUpNextAndSubmitButtons();
+
+    htmlForm.getBeforeValidation().push(function() {
+        //SL-1279, Last menstruation date should not be more than 10 months in the past of the encounter date
+        const lastPeriodElem = jq("#lastPeriodDate input[type='hidden']");
+        if ( lastPeriodElem ) {
+            const lastPeriodVal = lastPeriodElem.val();
+            if ( lastPeriodVal ) {
+                if ( daysBetweenUTCDates(new Date(lastPeriodVal), new Date(+encounterDate)) &gt; 305 ) {
+                    jq(window).scrollTop(jq("#lastPeriodDate").offset().top - 100);
+                    return false;
+                }
+            }
+        }
+        return true;
+    });
+});
+
+jq(document).ready(function() {
+
+    jq("#edd input[type='hidden']").change(function() {
+        const estimatedDelivery = this.value;
+        const estimatedDeliveryDate = new Date(estimatedDelivery);
+        if ( estimatedDeliveryDate.getTime() &gt; currentEncounterDate.getTime() ) {
+            // the estimated gestational age only makes sense if EDD is after the encounter time
+            const daysDiff = daysBetweenUTCDates(estimatedDeliveryDate, currentEncounterDate);
+            const diffWeeks = Math.floor( daysDiff / 7);
+            const gestAgeRemainderDays = daysDiff % 7;
+            const gestAge = diffWeeks + (gestAgeRemainderDays ? gestAgeRemainderDays / 10 : 0);
+            const estGestAge = (40 - gestAge).toFixed(1);
+            jq(".gestationalAge input[type='text']").val(estGestAge);
+        }
+    });
+
+    jq(".gestationalAge input[type='text']").change(function() {
+        const numValue = Number(this.value);
+        if (isNaN(numValue)) {
+            console.error("Gestational age must be a valid number");
+            return;
+        }
+        // EDD = (40 weeks - current estimated gestational age in weeks) * 7 days * 24 hours * 60 minutes * 60 seconds * 1000ms
+        const newEdd = new Date(currentEncounterDate.getTime() + (40 - numValue) * 7 * 24 * 60 * 60 * 1000);
+        getField("edd.value").datepicker("setDate", newEdd);
+    });
+});


### PR DESCRIPTION
This is a starter.  I think we should have another xml for followup or show-edd-and-ga, but they should share the same css and js files.

I think we still need to fix this code because there are still a few problems.  But hopefully if we pull the code into a few files it will be easier to maintain and modify.

I am also adding PRs for the sl htmlform files.