### PR TITLE
Change openmrs.log to append=true

### DIFF
--- a/configuration/log4j2.xml
+++ b/configuration/log4j2.xml
@@ -22,8 +22,8 @@
 		<Memory name="MEMORY_APPENDER" bufferSize="200"> <!-- bufferSize is how many messages are kept in memory -->
 			<PatternLayout pattern="${defaultPattern}" />
 		</Memory>
-		<!-- File appender - keeps an active openmrs.log in the application data directory.  Reset on restart -->
-		<File name="OPENMRS FILE APPENDER" fileName="${openmrs:applicationDirectory}/openmrs.log" append="false">
+		<!-- File appender - keeps an active openmrs.log in the application data directory. -->
+		<File name="OPENMRS FILE APPENDER" fileName="${openmrs:applicationDirectory}/openmrs.log" append="true">
 			<PatternLayout pattern="${defaultPattern}" />
 		</File>
 		<!-- Logging of user session and authentication events to the database. -->


### PR DESCRIPTION
After looking at options for persisting the docker stdout to disk, or save the catalina output to the log directory in the container, I think the better, more clear option is just to enable append for this log file to address UHM-9376.  I have tested this change on CI and confirmed it does address the issue, and that this file is setup in logrotate in puppet.  However, I realized when writing this PR that changing this here would also affect everyone's SDK, so it is probably better to overwrite this in puppet so it only affects the servers.

That said, that would also mean we are manually changing OpenMRS config at deploy time, which I don't think we do for any other config settings, so I wanted to submit this as a draft PR to get feedback.