### PR TITLE
HAI-1220: Remove test date restrictions to support historical and future entries

### DIFF
--- a/configuration/pih/htmlforms/labResults.xml
+++ b/configuration/pih/htmlforms/labResults.xml
@@ -139,8 +139,6 @@
                 })
                 const encounterDate = getDatePart(new Date(getValue('encounter-date.value'))) || new Date();
                 getField('encounter-date.value').datepicker('option', 'maxDate', new Date());
-                getField('test-date.value').datepicker('option', 'maxDate', null);
-                getField('test-date.value').datepicker('option', 'minDate', null);
                 getField('viral-load.value').change(toggleViralLoadFields);
                 toggleViralLoadFields();
             });

--- a/configuration/pih/htmlforms/labResults.xml
+++ b/configuration/pih/htmlforms/labResults.xml
@@ -139,8 +139,8 @@
                 })
                 const encounterDate = getDatePart(new Date(getValue('encounter-date.value'))) || new Date();
                 getField('encounter-date.value').datepicker('option', 'maxDate', new Date());
-                getField('test-date.value').datepicker('option', 'maxDate', new Date());
-                getField('test-date.value').datepicker('option', 'minDate', encounterDate);
+                getField('test-date.value').datepicker('option', 'maxDate', null);
+                getField('test-date.value').datepicker('option', 'minDate', null);
                 getField('viral-load.value').change(toggleViralLoadFields);
                 toggleViralLoadFields();
             });


### PR DESCRIPTION
Updated the test date validation to allow users to select both past and future dates.
Previously, the date picker was restricted by minDate and maxDate, which prevented selecting dates outside the allowed range. The restrictions have been removed to support more flexible date entry. @lnball @louidorjp 